### PR TITLE
Disable touch (update LastSeen time) for security sensors

### DIFF
--- a/devices/device.py
+++ b/devices/device.py
@@ -55,9 +55,13 @@ class Device():
         colorChanged = 'Color' in values and values['Color'] != device.Color
 
         if nValueChanged or sValueChanged or colorChanged or self.check_values_on_update == False:
+            Domoticz.Log( self.alias + " / " + device.Name);
             device.Update(**values)
         else:
-            self.touch_device(device)
+            if self.alias != "motion" and self.alias != "sensor":
+                self.touch_device(device)
+            else:
+                Domoticz.Debug("Skip touch for security sensors")
 
     def touch_device(self, device):
         # Touch has been added in recent Domoticz beta, so check if it exists for backward compatibility


### PR DESCRIPTION
I read the description of the touch function:
The touch () function updates the time the device was last viewed and nothing more. No events or notifications are triggered by touching the device.
After a call, the device displays the new value in the LastUpdate field of the device.

Therefore, for security sensors (with the "sensor" and "motion" alias), the touch function can be omitted. I tried to make changes for myself - and everything works great. The same can be done for a sensor with a type of "switch".

Heartbeat messages will come in other types: LinkQuality, BatteryVoltage, etc.